### PR TITLE
add a higher-level API for IORefs and MVars

### DIFF
--- a/foreign-store.cabal
+++ b/foreign-store.cabal
@@ -15,7 +15,7 @@ Homepage:            https://github.com/chrisdone/foreign-store
 library
   hs-source-dirs:    src/
   ghc-options:       -Wall -O2
-  exposed-modules:   Foreign.Store
+  exposed-modules:   Foreign.Store, Foreign.Store.Base
   build-depends:     base >= 4 && <5
   c-sources:         cbits/store.c
   include-dirs:      cbits

--- a/src/Foreign/Store/Base.hs
+++ b/src/Foreign/Store/Base.hs
@@ -1,0 +1,30 @@
+-- | Higher level API than Foreign.Store
+module Foreign.Store.Base where
+
+import Foreign.Store
+import Data.Word
+import Control.Concurrent
+import Data.IORef
+
+takeStoredMVar :: Word32 -> IO (MVar a)
+takeStoredMVar storeNum = do
+    var <- readStore (Store storeNum)
+    _ <- takeMVar var 
+    return var 
+
+modifyStoredIORef :: Store (IORef a) -> (a -> IO a) -> IO ()
+modifyStoredIORef store f = do
+  ref <- readStore store
+  readIORef ref >>= f >>= writeIORef ref 
+
+newStoredIORef :: a -> IO (IORef a)
+newStoredIORef x = do
+  ref <- newIORef x
+  _ <- newStore ref 
+  return ref 
+
+newStoredMVar :: IO (MVar a)
+newStoredMVar = do
+  var <- newEmptyMVar
+  _ <- newStore var 
+  return var


### PR DESCRIPTION
These functions help refactor the DevelMain.hs file into something a little nicer.

I don't like the module name of Base, but I couldn't think of anything better.
